### PR TITLE
修正result返回json解析错误与accountlist发送bug

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,5 +52,7 @@ func (cli *Client) AppDeviceNum() (int64, error) {
 		return 0, errors.New("<xinge> response err:" + response.Error())
 	}
 
-	return int64(response.Result["device_num"].(float64)), nil
+	result := response.Result.(map[string]interface{})
+
+	return int64(result["device_num"].(float64)), nil
 }

--- a/message.go
+++ b/message.go
@@ -14,21 +14,22 @@
 package xinge
 
 type AndroidMessage struct {
-	Title      string         `json:"title"`                 // 标题，必填
-	Content    string         `json:"content"`               // 内容，必填
-	AcceptTime []*AcceptTime  `json:"accept_time,omitempty"` //表示消息将在哪些时间段允许推送给用户，选填
-	NotifyId   byte           `json:"n_id,omitempty"`        //通知id，选填。若大于0，则会覆盖先前弹出的相同id通知；若为0，展示本条通知且不影响其他通知；若为-1，将清除先前弹出的所有通知，仅展示本条通知。默认为0
-	BuilderId  int            `json:"builder_id,omitempty"`  // 本地通知样式，必填
-	Ring       byte           `json:"ring,omitempty"`        // 是否响铃，0否，1是，下同。选填，默认1
-	RingRaw    string         `json:"ring_raw,omitempty"`    // 指定应用内的声音（ring.mp3），选填
-	Vibrate    byte           `json:"vibrate,omitempty"`     // 是否振动，选填，默认1
-	Lights     byte           `json:"lights,omitempty"`      // 是否呼吸灯，0否，1是，选填，默认1
-	Clearable  byte           `json:"clearable,omitempty"`   // 通知栏是否可清除，选填，默认1
-	IconType   byte           `json:"icon_type,omitempty"`   //默认0，通知栏图标是应用内图标还是上传图标,0是应用内图标，1是上传图标,选填
-	IconRes    string         `json:"icon_res,omitempty"`    // 应用内图标文件名（xg.png）或者下载图标的url地址，选填
-	StyleId    byte           `json:"style_id,omitempty"`    //Web端设置是否覆盖编号的通知样式，默认1，0否，1是,选填
-	SmailIcon  string         `json:"smail_icon,omitempty"`  //指定状态栏的小图片(xg.png),选填
-	Action     *AndroidAction `json:"action,omitempty"`      // 动作，选填。默认为打开app
+	Title         string                 `json:"title"`                 // 标题，必填
+	Content       string                 `json:"content"`               // 内容，必填
+	AcceptTime    []*AcceptTime          `json:"accept_time,omitempty"` //表示消息将在哪些时间段允许推送给用户，选填
+	NotifyId      byte                   `json:"n_id,omitempty"`        //通知id，选填。若大于0，则会覆盖先前弹出的相同id通知；若为0，展示本条通知且不影响其他通知；若为-1，将清除先前弹出的所有通知，仅展示本条通知。默认为0
+	BuilderId     int                    `json:"builder_id,omitempty"`  // 本地通知样式，必填
+	Ring          byte                   `json:"ring,omitempty"`        // 是否响铃，0否，1是，下同。选填，默认1
+	RingRaw       string                 `json:"ring_raw,omitempty"`    // 指定应用内的声音（ring.mp3），选填
+	Vibrate       byte                   `json:"vibrate,omitempty"`     // 是否振动，选填，默认1
+	Lights        byte                   `json:"lights,omitempty"`      // 是否呼吸灯，0否，1是，选填，默认1
+	Clearable     byte                   `json:"clearable,omitempty"`   // 通知栏是否可清除，选填，默认1
+	IconType      byte                   `json:"icon_type,omitempty"`   //默认0，通知栏图标是应用内图标还是上传图标,0是应用内图标，1是上传图标,选填
+	IconRes       string                 `json:"icon_res,omitempty"`    // 应用内图标文件名（xg.png）或者下载图标的url地址，选填
+	StyleId       byte                   `json:"style_id,omitempty"`    //Web端设置是否覆盖编号的通知样式，默认1，0否，1是,选填
+	SmailIcon     string                 `json:"smail_icon,omitempty"`  //指定状态栏的小图片(xg.png),选填
+	Action        *AndroidAction         `json:"action,omitempty"`      // 动作，选填。默认为打开app
+	CustomContent map[string]interface{} `json:"custom_content"`
 }
 
 type AcceptTime struct {
@@ -42,13 +43,12 @@ type HourMin struct {
 }
 
 type AndroidAction struct {
-	ActionType    byte                   `json:"action_type"` // 动作类型，1打开activity或app本身，2打开浏览器，3打开Intent，4通过包名拉起其他应用
-	Activity      string                 `json:"activity"`
-	AtyAttr       *ActivityAttr          `json:"aty_attr"` // activity属性，只针对action_type=1的情况
-	Browser       *Browser               `json:"browser"`
-	IntenterNet   string                 `json:"intent"`
-	PackageName   *Package               `json:"package_name"`
-	CustomContent map[string]interface{} `json:"custom_content"`
+	ActionType  byte          `json:"action_type"` // 动作类型，1打开activity或app本身，2打开浏览器，3打开Intent，4通过包名拉起其他应用
+	Activity    string        `json:"activity"`
+	AtyAttr     *ActivityAttr `json:"aty_attr"` // activity属性，只针对action_type=1的情况
+	Browser     *Browser      `json:"browser"`
+	IntenterNet string        `json:"intent"`
+	PackageName *Package      `json:"package_name"`
 }
 
 type ActivityAttr struct {

--- a/message.go
+++ b/message.go
@@ -75,6 +75,6 @@ type IosMessage struct {
 
 type ApsAttr struct {
 	Alert string `json:"alert"`
-	Badge string `json:"badge,omitempty"`
+	Badge int    `json:"badge,omitempty"`
 	Sound string `json:"sound,omitempty"`
 }

--- a/message.go
+++ b/message.go
@@ -67,3 +67,14 @@ type Package struct {
 	PackageDLUrl string `json:"packageDownloadUrl"` //拉起应用的下载链接（若客户端没有找到此应用会自动去下载）
 	Confirm      byte   `json:"confirm"`            //是否确认
 }
+
+type IosMessage struct {
+	Aps           *ApsAttr               `json:"aps"`
+	CustomContent map[string]interface{} `json:"custom_content,omitempty"` //参考android的自定义属性
+}
+
+type ApsAttr struct {
+	Alert string `json:"alert"`
+	Badge string `json:"badge,omitempty"`
+	Sound string `json:"sound,omitempty"`
+}

--- a/push.go
+++ b/push.go
@@ -91,16 +91,26 @@ func (req *ReqPush) Push() error {
 		if androidMsg, ok := req.Message.(*AndroidMessage); ok {
 			androidMessage, err := json.Marshal(androidMsg)
 			if err != nil {
-				return errors.New("<xinge> marshal message err:" + err.Error())
+				return errors.New("<xinge> marshal android message err:" + err.Error())
 			}
 
 			message = string(androidMessage)
 		} else {
-			return errors.New("<xinge> invalid message content.")
+			return errors.New("<xinge> invalid android message content.")
 		}
 
 	case Platform_ios:
+		// message
+		if iosMsg, ok := req.Message.(*IosMessage); ok {
+			iosMessage, err := json.Marshal(iosMsg)
+			if err != nil {
+				return errors.New("<xinge> marshal ios message err:" + err.Error())
+			}
 
+			message = string(iosMessage)
+		} else {
+			return errors.New("<xinge> invalid ios message content.")
+		}
 	}
 	request.SetParam("message", message)
 

--- a/push.go
+++ b/push.go
@@ -37,10 +37,6 @@ type ReqPush struct {
 	Cli          *Client
 }
 
-type Account struct {
-	Account string `json:"account"`
-}
-
 func (req *ReqPush) Push() error {
 	var request *Request
 
@@ -53,12 +49,8 @@ func (req *ReqPush) Push() error {
 		request.SetParam("account", req.UserAccounts[0])
 	case PushType_multi_account:
 		request = req.Cli.NewRequest("GET", multiAccountUrl)
-		accountList := make([]*Account, 0)
-		for _, account := range req.UserAccounts {
-			accountList = append(accountList, &Account{account})
-		}
 
-		accounts, err := json.Marshal(accountList)
+		accounts, err := json.Marshal(req.UserAccounts)
 		if err != nil {
 			return errors.New("<xinge> marshal account list err:" + err.Error())
 		}

--- a/response.go
+++ b/response.go
@@ -14,9 +14,9 @@
 package xinge
 
 type Response struct {
-	RetCode int                    `json:"ret_code"`
-	ErrMsg  string                 `json:"err_msg,omitempty"`
-	Result  map[string]interface{} `json:"result,omitempty"`
+	RetCode int         `json:"ret_code"`
+	ErrMsg  string      `json:"err_msg,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
 }
 
 func (rsp *Response) OK() bool {

--- a/tags.go
+++ b/tags.go
@@ -32,7 +32,7 @@ func (cli *Client) AppTags(start, limit int) (int64, []string, error) {
 		return 0, tags, errors.New("<xinge> response err:" + response.Error())
 	}
 
-	result := response.Result
+	result := response.Result.(map[string]interface{})
 	total := int64(result["total"].(float64))
 	if total <= 0 {
 		return 0, tags, nil
@@ -108,7 +108,8 @@ func (cli *Client) TokenTags(token string) ([]string, error) {
 		return tags, errors.New("<xinge> response err:" + response.Error())
 	}
 
-	tagList := response.Result["tags"].([]interface{})
+	result := response.Result.(map[string]interface{})
+	tagList := result["tags"].([]interface{})
 	for _, tag := range tagList {
 		tags = append(tags, tag.(string))
 	}
@@ -129,5 +130,6 @@ func (cli *Client) TagTokensNum(tag string) (int64, error) {
 		return 0, errors.New("<xinge> response err:" + response.Error())
 	}
 
-	return int64(response.Result["device_num"].(float64)), nil
+	result := response.Result.(map[string]interface{})
+	return int64(result["device_num"].(float64)), nil
 }


### PR DESCRIPTION
1. accountlist发送时格式错误，接口需要的是

``` javascript
["string","string"]
```

之前被转换为了

``` javascript
[{"account":"string" },{"account":"string" },{"account":"string" }]
```
1. result 返回结果当前强制为map[string]interface{}解析，但目标有可能返回一个数组，参考accout_list发送相关文档。
   当前修改为interface{}结构，并在使用时再进行类型判断。
